### PR TITLE
docker dev workflow support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,0 @@
-[submodule "thirdparty/downward"]
-	path = thirdparty/downward
-	url = https://github.com/aibasel/downward.git
-[submodule "thirdparty/ompl"]
-	path = thirdparty/ompl
-	url = https://github.com/ompl/ompl.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,13 +22,21 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-# subdirectories
-add_subdirectory(thirdparty)
+find_package(Eigen3 REQUIRED)
+find_package(yaml-cpp REQUIRED)
+find_package(ompl REQUIRED)
+find_package(behaviortree_cpp REQUIRED)
+
 add_subdirectory(src)
-add_subdirectory(bindings)
+
+option(TAMPL_BUILD_PYBINDINGS "Build python bindings." ON)
+if(TAMPL_BUILD_PYBINDINGS)
+  message(STATUS "Building python bindings...")
+  add_subdirectory(bindings)
+endif()
 
 option(TAMPL_BUILD_EXAMPLES "Build example applications." ON)
 if(TAMPL_BUILD_EXAMPLES)
-  message(STATUS "Building example applications.")
+  message(STATUS "Building example applications...")
   add_subdirectory(examples)
 endif()

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,84 @@
+# Use the official Ubuntu 22.04 image as the base image
+FROM ubuntu:22.04 as base
+
+# Set shell for running commands
+SHELL ["/bin/bash", "-c"]
+
+# Install essential packages
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
+    build-essential \
+    cmake \
+    curl \
+    git \
+    g++ \
+    libgtest-dev \
+    libx11-6 \
+    libx11-dev \
+    mesa-utils \
+    # required by ompl
+    libboost-serialization-dev \
+    libboost-filesystem-dev \
+    libboost-system-dev \
+    libboost-program-options-dev \
+    libboost-test-dev \
+    libeigen3-dev \
+    libode-dev \
+    libyaml-cpp-dev \
+    # required by BTCPP
+    libzmq3-dev \
+    libsqlite3-dev \
+    pkg-config \
+    python3-dev python3-venv python3-pip python3-setuptools \
+    wget && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV LANG en_GB.UTF-8
+ENV LANGUAGE en_GB.UTF-8
+
+RUN python3 -m pip install --upgrade pip
+
+ENV CXX=g++
+ENV MAKEFLAGS="-j8"
+
+# install BehaviorTree.CPP (v4.6.2) from source
+RUN wget https://github.com/BehaviorTree/BehaviorTree.CPP/archive/refs/tags/4.6.2.tar.gz -O /opt/BehaviorTree.CPP-4.6.2.tar.gz && \
+    tar -xzf /opt/BehaviorTree.CPP-4.6.2.tar.gz -C /opt && \
+    rm /opt/BehaviorTree.CPP-4.6.2.tar.gz && \
+    cd /opt/BehaviorTree.CPP-4.6.2 && \
+    mkdir build && cd build && \
+    cmake -DBTCPP_UNIT_TESTS=OFF -DBTCPP_EXAMPLES=OFF .. && \
+    make && make install
+
+# install ompl (v1.6.0) from source
+RUN wget https://github.com/ompl/ompl/archive/refs/tags/1.6.0.tar.gz -O /opt/ompl-1.6.0.tar.gz && \
+    tar -xzf /opt/ompl-1.6.0.tar.gz -C /opt && \
+    rm /opt/ompl-1.6.0.tar.gz && \
+    cd /opt/ompl-1.6.0 && \
+    mkdir -p build/Release && \
+    cd build/Release && \
+    cmake ../.. -DOMPL_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXEC=/usr/bin/python3 && \
+    make && make install
+
+# Create a symlink for 'python' to 'python3'
+RUN ln -sf /usr/bin/python3 /usr/bin/python
+
+# Create a workspace
+WORKDIR /workspace
+
+# Install Python dependencies
+COPY requirements.txt /workspace/
+RUN pip3 install --upgrade pip && \
+    pip3 install --no-cache-dir -r /workspace/requirements.txt
+
+FROM base AS dev
+
+ENV PYTHONUNBUFFERED=1
+
+# Set entrypoint script
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+WORKDIR /workspace
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,9 @@ RUN apt-get update && \
     wget && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# add custom library paths to the dynamic linker configuration
+RUN echo "/usr/local/lib" >> /etc/ld.so.conf.d/99local.conf && ldconfig
+
 ENV LANG en_GB.UTF-8
 ENV LANGUAGE en_GB.UTF-8
 

--- a/README.md
+++ b/README.md
@@ -1,24 +1,74 @@
 # Task and Motion Planning Library (TAMPL)
 
-## Build instructions for development (temporary)
+## Development Guide
 
-### setup
-```
-$ git clone --recursive https://github.com/mlsdpk/tampl.git
-$ python -m venv tampl_venv
-$ source tampl_venv/bin/activate
-$ pip install -r requirements.txt
-```
+### Prerequisites
 
-### build and install pytampl
-```
-$ pip install . --config-settings=build.tool-args=-j8
-```
+**Docker**: Ensure you have Docker installed on your machine. You can download and install Docker from [here](https://docs.docker.com/engine/install/).
 
-### build and install pytampl-extensions
-```
-$ cd extensions && pip install .
-```
+### First-Time Setup
+
+1. **Clone the Repository**
+   Clone the repository to your local machine:
+   ```bash
+   $ git clone https://github.com/mlsdpk/tampl.git
+   $ cd tampl
+   ```
+
+2. **Set Up the Development Environment**
+   Run the following command **from the repository's top-level directory** to build and launch the development environment:
+   ```bash
+   $ docker-compose up --build dev
+   ```
+   > **Note:** This process will install all necessary dependencies and may take some time, depending on your machine's performance.
+
+   If successful, you should see output similar to:
+   ```plaintext
+   => => naming to docker.io/library/tampl:dev
+   [+] Running 1/1
+    ✔ Container tampl-dev-1  Recreated
+   Attaching to tampl-dev-1
+   ```
+
+### GUI Support
+
+If your development workflow requires a graphical user interface (GUI), follow these steps to enable GUI access via **NoVNC**:
+
+1. **Launch the NoVNC Service**
+   Open a new terminal, navigate to the repository's top-level directory, and execute:
+   ```bash
+   $ docker-compose up --build novnc
+   ```
+   This will start a NoVNC server that provides a browser-based VNC (Virtual Network Computing) interface for interacting with your development container’s GUI.
+
+2. **Access the GUI**
+   Open a web browser and go to:
+   [http://localhost:8080/vnc.html](http://localhost:8080/vnc.html)
+
+   You should now see the graphical interface of your Docker container.
+
+### Development Workflow
+
+1. **Access the Development Container**
+   Ensure the development container is running (see the [First-Time Setup](#first-time-setup) section). Open a new terminal and run:
+   ```bash
+   $ docker exec -it tampl-dev-1 bash
+   ```
+
+   This command will give you an interactive shell inside the container.
+
+2. **Build and Install `pytampl`**
+   To build and install the core `pytampl` module, run:
+   ```bash
+   $ pip install . --config-settings=build.tool-args=-j8
+   ```
+
+3. **Build and Install `pytampl-extensions`**
+   To build and install the `pytampl-extensions` module, navigate to the `extensions` directory:
+   ```bash
+   $ cd extensions
+   $ pip install .
+   ```
 
 ## Use Cases / Examples
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 2. **Set Up the Development Environment**
    Run the following command **from the repository's top-level directory** to build and launch the development environment:
    ```bash
-   $ docker-compose up --build dev
+   $ docker compose up --build dev
    ```
    > **Note:** This process will install all necessary dependencies and may take some time, depending on your machine's performance.
 
@@ -37,7 +37,7 @@ If your development workflow requires a graphical user interface (GUI), follow t
 1. **Launch the NoVNC Service**
    Open a new terminal, navigate to the repository's top-level directory, and execute:
    ```bash
-   $ docker-compose up --build novnc
+   $ docker compose up --build novnc
    ```
    This will start a NoVNC server that provides a browser-based VNC (Virtual Network Computing) interface for interacting with your development container’s GUI.
 

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -1,4 +1,5 @@
-find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)
+find_package(Python3 REQUIRED COMPONENTS Interpreter Development.Module)
+set(PYBIND11_FINDPYTHON ON)
 find_package(pybind11 CONFIG REQUIRED)
 
 add_subdirectory(pytampl)

--- a/bindings/pytampl/planner/__init__.py
+++ b/bindings/pytampl/planner/__init__.py
@@ -1,1 +1,2 @@
-from .planner import FastForward
+# comment this until temporal Fast Downward is supported
+# from .planner import FastForward

--- a/bindings/pytampl/planner/bindings.cpp
+++ b/bindings/pytampl/planner/bindings.cpp
@@ -1,22 +1,22 @@
 #include "pytampl/typedefs.hpp"
-#include "tampl/planner/fast_forward/fast_forward.hpp"
+// #include "tampl/planner/fast_forward/fast_forward.hpp"
 #include "tampl/planner/ompl/ompl.hpp"
 
 namespace tampl::pytampl {
 
 PYBIND11_MODULE(planner, m) {
-  using class_t = tampl::planner::FastForward;
+//   using class_t = tampl::planner::FastForward;
   using base_class_t = tampl::core::Planner;
 
   py::class_<base_class_t>(m, "Planner")
-      .def("get_solution", &class_t::get_solution);
+      .def("get_solution", &base_class_t::get_solution);
 
   ///////////////////////////////////////////////////////////////////
 
   // TODO(Phone): move this under task specific submodule
-  py::class_<class_t, base_class_t>(m, "FastForward")
-      .def(py::init<>())
-      .def("solve", &class_t::solve);
+//   py::class_<class_t, base_class_t>(m, "FastForward")
+//       .def(py::init<>())
+//       .def("solve", &class_t::solve);
 
   ///////////////////////////////////////////////////////////////////
 

--- a/cmake/tampl-config.cmake.in
+++ b/cmake/tampl-config.cmake.in
@@ -1,0 +1,9 @@
+@PACKAGE_INIT@
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+
+include("${CMAKE_CURRENT_LIST_DIR}/tampl-targets.cmake")
+
+if(NOT tampl_FIND_QUIETLY)
+  message(STATUS "Found tampl version ${TAMPL_VERSION}")
+endif()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+version: "3.9"
+services:
+  base:
+    image: tampl:base
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: base
+    # Interactive shell
+    stdin_open: true
+    tty: true
+    # Needed to display graphical applications
+    network_mode: host
+    privileged: true
+  dev:
+    image: tampl:dev
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: dev
+      args:
+        UID: ${UID:-1000}
+        GID: ${GID:-1000}
+    environment:
+      - DISPLAY=novnc:0.0
+    networks:
+      - x11
+    volumes:
+      # Mount source code
+      - .:/workspace:rw
+    command: sleep infinity
+  novnc:
+    image: theasp/novnc:latest
+    environment:
+      - DISPLAY_WIDTH=2560
+      - DISPLAY_HEIGHT=1440
+    ports:
+      - "8080:8080"
+    networks:
+      - x11
+    restart: on-failure
+networks:
+  x11:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# If no command is provided, start a bash shell
+if [[ $# -eq 0 ]]; then
+    exec bash
+else
+    # Execute the provided command
+    exec "$@"
+fi

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -3,4 +3,4 @@ macro(_tampl_add_example name)
     target_link_libraries(tampl_example_${name} PRIVATE tampl)
 endmacro()
 
-_tampl_add_example(test_task_planning)
+# _tampl_add_example(test_task_planning)

--- a/extensions/src/pytampl/extensions/pybullet/env/env.py
+++ b/extensions/src/pytampl/extensions/pybullet/env/env.py
@@ -150,7 +150,7 @@ class PyBulletEnv(Environment):
 
             # only supports revolute joint for now
             if joint_info[idx["jointType"]] != pybullet.JOINT_FIXED:
-                print(f"joint name: {joint_info[idx["jointName"]]}, lower: {joint_info[idx["jointLowerLimit"]]}, upper: {joint_info[idx["jointUpperLimit"]]} q: ", q)
+                print(f"joint name: {joint_info[idx['jointName']]}, lower: {joint_info[idx['jointLowerLimit']]}, upper: {joint_info[idx['jointUpperLimit']]} q: {q}")
                 bounds.append((joint_info[idx["jointLowerLimit"]], joint_info[idx["jointUpperLimit"]]))
 
         return bounds

--- a/include/tampl/core/action.hpp
+++ b/include/tampl/core/action.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ build-dir = "build/{wheel_tag}/{build_type}"
 wheel.exclude = ["**.cpp", "**.hpp", "**.txt"]
 logging.level = "INFO"
 build.verbose = true
-cmake.args = ["-DOMPL_BUILD_TESTS=OFF"]
 
 [tool.setuptools.packages.find]
 where = ["bindings"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,9 @@
-pddlgym # move this to extensions
-pybullet
+packaging==24.2
+pytest
 pybind11-global
+pddl==0.4.1
+
+# TODO: make the followings as optional tampl extensions
+pddlgym
+pygame
+pybullet==3.2.6

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,8 @@ include(GNUInstallDirs)
 set(TAMPL_CONFIG_INSTALL_DIR "${CMAKE_INSTALL_DATADIR}/cmake/tampl")
 set(TAMPL_INCLUDE_INSTALL_DIR "${CMAKE_INSTALL_INCLUDEDIR}/tampl")
 set(TAMPL_TARGETS_EXPORT_NAME "tampl-targets")
+set(TAMPL_CMAKE_CONFIG_TEMPLATE
+    "${PROJECT_SOURCE_DIR}/cmake/tampl-config.cmake.in")
 set(TAMPL_CMAKE_CONFIG_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 set(TAMPL_CMAKE_VERSION_CONFIG_FILE
     "${TAMPL_CMAKE_CONFIG_DIR}/tampl-config-version.cmake")
@@ -28,7 +30,6 @@ set(CMAKE_INSTALL_RPATH "${_rpath_portable_origin}")
 # outside the build tree to the install RPATH
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
-find_package(Eigen3 REQUIRED)
 # create tampl as an empty lib for now
 add_library(${PROJECT_NAME} SHARED)
 
@@ -44,24 +45,44 @@ set(SRC_FILES tampl.cpp ${_agent_src_files} ${_core_src_files}
 target_sources(${PROJECT_NAME} PRIVATE ${SRC_FILES})
 target_include_directories(
   ${PROJECT_NAME}
-  PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/>
-         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-         $<BUILD_INTERFACE:${EIGEN3_INCLUDE_DIR}>
-         $<INSTALL_INTERFACE:${TAMPL_INCLUDE_INSTALL_DIR}>)
-target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC "${Boost_INCLUDE_DIR}")
+  PUBLIC
+    ${OMPL_INCLUDE_DIRS}
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${EIGEN3_INCLUDE_DIR}>
+    $<INSTALL_INTERFACE:${TAMPL_INCLUDE_INSTALL_DIR}>)
 
-# ompl related
-set(OMPL_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/thirdparty/ompl/src")
-target_include_directories(
+target_link_libraries(
   ${PROJECT_NAME}
-  PUBLIC $<BUILD_INTERFACE:${OMPL_INCLUDE_DIRS}>
-         # for ompl/config.h
-         $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/thirdparty/ompl/src>)
-target_link_libraries(${PROJECT_NAME} PUBLIC ompl)
+  PUBLIC
+    ompl
+    behaviortree_cpp
+    ${YAMLCPP_LIBRARIES})
+
+if(TAMPL_BUILD_PYBINDINGS)
+  target_include_directories(
+    ${PROJECT_NAME}
+    PUBLIC
+      $<BUILD_INTERFACE:${PYBIND11_INCLUDE_DIR}>
+      $<BUILD_INTERFACE:${Python3_INCLUDE_DIRS}>)
+
+  target_link_libraries(
+    ${PROJECT_NAME}
+    PUBLIC
+      ${pybind11_LIBRARIES}
+      pybind11::module
+      pybind11::pybind11
+      pybind11::embed
+      ${Python3_LIBRARIES})
+endif()
 
 set_target_properties(
   ${PROJECT_NAME} PROPERTIES OUTPUT_NAME "${PROJECT_NAME}-${TAMPL_VERSION}"
                              POSITION_INDEPENDENT_CODE ON)
+
+# Make sure OS X does not have any issues with missing symbols
+if(APPLE)
+  target_link_libraries(${PROJECT_NAME} PRIVATE "-undefined dynamic_lookup")
+endif(APPLE)
 
 # INSTALL
 
@@ -69,6 +90,10 @@ set_target_properties(
 include(CMakePackageConfigHelpers)
 set(VERSION_FILE
     "${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}-config-version.cmake")
+configure_package_config_file(
+  ${TAMPL_CMAKE_CONFIG_TEMPLATE} ${TAMPL_CMAKE_PROJECT_CONFIG_FILE}
+  INSTALL_DESTINATION ${TAMPL_CONFIG_INSTALL_DIR}
+  NO_SET_AND_CHECK_MACRO NO_CHECK_REQUIRED_COMPONENTS_MACRO)
 write_basic_package_version_file(
   ${TAMPL_CMAKE_VERSION_CONFIG_FILE}
   VERSION ${TAMPL_VERSION}
@@ -84,7 +109,7 @@ set_target_properties(
              "${CMAKE_INSTALL_RPATH}:${_rpath_portable_origin}/../lib")
 
 install(
-  TARGETS ${PROJECT_NAME} ompl
+  TARGETS ${PROJECT_NAME}
   EXPORT ${TAMPL_TARGETS_EXPORT_NAME}
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/src/planner/CMakeLists.txt
+++ b/src/planner/CMakeLists.txt
@@ -1,9 +1,9 @@
+# Comment out the planners until build issues are resolved
 set(_planner_src_files
-    ${CMAKE_CURRENT_SOURCE_DIR}/fast_forward/fast_forward.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/fast_downward/fast_downward.cpp
+    # ${CMAKE_CURRENT_SOURCE_DIR}/fast_forward/fast_forward.cpp
+    # ${CMAKE_CURRENT_SOURCE_DIR}/fast_downward/fast_downward.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ompl/ompl.cpp
     PARENT_SCOPE)
 
-add_subdirectory(fast_forward)
-add_subdirectory(fast_downward)
-# add_subdirectory(ompl)
+# add_subdirectory(fast_forward)
+# add_subdirectory(fast_downward)

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -1,2 +1,0 @@
-add_subdirectory(downward/src)
-add_subdirectory(ompl)


### PR DESCRIPTION
Major changes:
- Removed submodules.
- Disabled the FastForward planner as it is not supported on Jazzy (deprecated it in favor of using Temporal FastDownward moving forward).
- Relied on containers to accelerate the development workflow.
- Included NoVNC support for Mac since [XQuartz](https://github.com/XQuartz/XQuartz) is not happy with Apple Silicon chips (see [here](https://github.com/XQuartz/XQuartz/issues/335) and [here](https://github.com/XQuartz/XQuartz/issues/335))